### PR TITLE
Update lab10.rst

### DIFF
--- a/docs/class4/module1/lab10.rst
+++ b/docs/class4/module1/lab10.rst
@@ -17,7 +17,7 @@ Beginning with v15.x of BIG-IP there is a tcpdump option that has been added tha
    .. code-block:: bash
       :linenos:
 
-      tcpdump -nni 0.0:nnnp -s0 -w /var/tmp/hackazon-ssl.pcap host 10.1.20.103 --f5 ssl 
+      tcpdump -nni 0.0:nnn -s0 -w /var/tmp/hackazon-ssl.pcap host 10.1.20.103 --f5 ssl 
 
    .. NOTE:: Notice that we've got a warning message because Master Secret will be copied to tcpdump capture itself, so we need to be careful with who we share such capture with.
 


### PR DESCRIPTION
Please do not use the 'p' flag when capturing traffic.  There is a specific use case for it, and most cases is not it.  Using the 'p' flag when not explicitly needed in the best case scenario creates difficult to interpret capture files, in the worst case scenario creates performance impact even after tcpdump is no longer running.

See notes at https://support.f5.com/csp/article/K13637#specificflow for details.