### PR TITLE
Update lab10.rst

### DIFF
--- a/docs/class4/module1/lab10.rst
+++ b/docs/class4/module1/lab10.rst
@@ -64,7 +64,7 @@ Automate Pre Master Secret File Creation
       
       "c:\Program Files\Wireshark"\tshark.exe -r c:\users\user\Documents\hackazon-ssl.pcap -Y "f5ethtrailer.tls.keylog" -T fields -e f5ethtrailer.tls.keylog >> c:\users\user\Documents\session.pms
 
-   .. NOTE:: The command is in the format of: **"tshark.exe -r <packet capture file> -Y "f5ethtrailer.tls.keylog" -T fields -e f5.ethtrailers.tls.keylog >> <file to write to>"**
+   .. NOTE:: The command is in the format of: **"tshark.exe -r <packet capture file> -Y "f5ethtrailer.tls.keylog" -T fields -e f5.ethtrailer.tls.keylog >> <file to write to>"**
              
              The -Y sets a display filter, the -T says to look for Field values, -e pulls tha values from the fields.
 


### PR DESCRIPTION
Correction details: There is a type in this word 'f5.ethtrailers.tls.keylog' where trailing 's' need to be removed and it should look  like 'f5.ethtrailer.tls.keylog'
 Incorrect:
 <> 
 Note
 The command is in the format of: "tshark.exe -r <packet capture file> -Y "f5ethtrailer.tls.keylog" -T fields -e f5.ethtrailers.tls.keylog >> <file to write to>"
 </>
 Need to correct this to:
 <> 
 Note
 The command is in the format of: "tshark.exe -r <packet capture file> -Y "f5ethtrailer.tls.keylog" -T fields -e f5.ethtrailer.tls.keylog >> <file to write to>"