### PR TITLE
Remove 'p' flag from packet captures

### DIFF
--- a/docs/class4/module1/lab03.rst
+++ b/docs/class4/module1/lab03.rst
@@ -44,11 +44,3 @@ F5 has added some F5 specific switches to the tcpdump utility on the F5.  These 
        * Peer local port
 
     .. image:: /_static/class4/tcpdump-nnn.png
-
-#. **:nnnp** captures traffic on both the client and server side of the F5 related to the filter.  For example if I captured for a virtual server at IP address 10.1.20.103 and the pool members were 10.1.10.5, 10.1.10.6, and 10.1.10.7, and my host filter was for 10.1.20.103, then my capture would gather all the traffic from client to 10.1.20.103 and from BIG-IP to the pool members.
-
-     a. for example: **tcpdump -nni 0.0:nnnp -s0 -w/var/tmp/capture.pcap**
-
-     b. This option will capture all traffic coming into the BIG-IP and correlated traffic going to all pool members.
-
-     

--- a/docs/class4/module1/lab05.rst
+++ b/docs/class4/module1/lab05.rst
@@ -17,7 +17,7 @@ Let's take the information we have gathered so far and take a packet capture fro
 
    .. code-block:: bash
       
-      tcpdump -nni 0.0:nnnp -s0 -w /var/tmp/hackazon.pcap host 10.1.20.103
+      tcpdump -nni 0.0:nnn -s0 -w /var/tmp/hackazon.pcap host 10.1.20.103
 
 #. After starting the capture, start Chrome and click on the Hackazon bookmark.  Browse around the site following a couple links.  Next go to the address bar and type in: "http://10.1.20.103:8443".  Then stop the capture in the putty session by using 'Ctrl+c'.
 

--- a/docs/class4/module1/lab12.rst
+++ b/docs/class4/module1/lab12.rst
@@ -63,7 +63,7 @@ SSL Decrypt from Windows Client
 
 #. In our lab environment there is a shortcut on the desktop to connect to the environment variables.
 
-#. Now start the tcpdump on the F5 box similar to: 'tcpdump -nni 0.0:nnnp -s0 -w /var/tmp/ssl.pcap host 10.1.20.103'
+#. Now start the tcpdump on the F5 box similar to: 'tcpdump -nni 0.0:nnn -s0 -w /var/tmp/ssl.pcap host 10.1.20.103'
 
 #. Once the system variable has been put in place you can then launch a web browser and start the traffic that you want to analyze.
 


### PR DESCRIPTION
Please do not use the 'p' flag when capturing traffic. There is a
specific use case for it, and most cases is not it. Using the 'p' flag
when not explicitly needed in the best case scenario creates difficult
to interpret capture files, in the worst case scenario creates
performance impact even after tcpdump is no longer running.

In fact, please discourage use of the 'p' flag.

Also see https://github.com/f5devcentral/f5-agility-labs-adc/pull/43

See notes at https://support.f5.com/csp/article/K13637#specificflow for details.