### PR TITLE
Class9 Module1: Remove duplicate Lab section from outer_layer_content

### DIFF
--- a/docs/class9/module1_outer/outer_layer_content.rst
+++ b/docs/class9/module1_outer/outer_layer_content.rst
@@ -151,14 +151,6 @@ This validation confirms that:
 
 For detailed configuration steps and validation exercises, see:
 
-Lab
-===
-
-.. toctree::
-   :maxdepth: 1
-
-   lab/index
-
 Route Domain and Segmentation Controls
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR removes a duplicate "Lab" toctree block from
docs/class9/module1_outer/outer_layer_content.rst.

Previously, the Outer Layer page rendered two Lab sections:
1. A structural lab navigation block
2. The actual lab listing

This change removes the redundant toctree entry so that:
- The Outer Layer page contains a single Lab section
- Navigation remains consistent with Module2 and Module3
- RTD symmetry is preserved across all layers

No functional lab content was modified.
Documentation structure only.